### PR TITLE
fixing path to toc

### DIFF
--- a/sandbox/TOC.yml
+++ b/sandbox/TOC.yml
@@ -2,5 +2,5 @@
   href: index.yml
   items:
     - name: Demos
-      href: /sandbox/demos/TOC.yml
+      href: ./sandbox/demos/TOC.yml
       expanded: true


### PR DESCRIPTION
This might be an issue where you've got the wrong path. If you start with a `/`, that creates a path relative to the site root. I've modified your path so that it's relative to the ToC. Let me know if this caused the nested ToC to work properly.