### PR TITLE
link fixes

### DIFF
--- a/sandbox/demos/TOC.yml
+++ b/sandbox/demos/TOC.yml
@@ -2,8 +2,8 @@
   href: index.yml
   items:
   - name: GitHubBot
-    href: /sandbox/demos/githubbot
+    href: githubbot
   - name: NotBacon
-    href: /sandbox/demos/notbacon
+    href: notbacon
   - name: NotHotdog
-    href: /sandbox/demos/nothotdog
+    href: nothotdog


### PR DESCRIPTION
The / at the beginning references the root of the docs site. Let's see if this fixes the toc validation.