### PR TITLE
Adding more Cosmos DB samples

### DIFF
--- a/sandbox/functions-recipes/cosmos-db.md
+++ b/sandbox/functions-recipes/cosmos-db.md
@@ -14,14 +14,14 @@ ms.author: antchu
 
 # Cosmos DB (DocumentDB) Bindings
 
-[!include[](includes/cosmos-db-documentdbclient.md)]
-
 [!include[](includes/cosmos-db-id.md)]
 
 [!include[](includes/cosmos-db-sqlquery.md)]
 
 [!include[](includes/cosmos-db-outputcollector.md)]
 
-[!include[](includes/cosmos-db-staticclient.md)]
-
 [!include[](includes/cosmos-db-livemigration.md)]
+
+[!include[](includes/cosmos-db-documentdbclient.md)]
+
+[!include[](includes/cosmos-db-staticclient.md)]

--- a/sandbox/functions-recipes/cosmos-db.md
+++ b/sandbox/functions-recipes/cosmos-db.md
@@ -19,3 +19,9 @@ ms.author: antchu
 [!include[](includes/cosmos-db-id.md)]
 
 [!include[](includes/cosmos-db-sqlquery.md)]
+
+[!include[](includes/cosmos-db-outputcollector.md)]
+
+[!include[](includes/cosmos-db-staticclient.md)]
+
+[!include[](includes/cosmos-db-livemigration.md)]

--- a/sandbox/functions-recipes/cosmos-db.md
+++ b/sandbox/functions-recipes/cosmos-db.md
@@ -8,7 +8,7 @@ ms.service: functions
 ms.devlang: dotnet
 ms.topic: article
 ms.workload: na
-ms.date: 10/12/2017
+ms.date: 03/27/2018
 ms.author: antchu
 ---
 

--- a/sandbox/functions-recipes/includes/cosmos-db-livemigration.md
+++ b/sandbox/functions-recipes/includes/cosmos-db-livemigration.md
@@ -1,0 +1,36 @@
+## Trigger a Function based on changes in Cosmos DB
+
+You can trigger a Function based on changes in your Cosmos DB collections. In this sample we are sending the changes to a second collection using the `IAsyncCollection` explained in [this other recipe](./cosmos-db-outputcollector). You could process or work with the documents before sending it to the second collection.
+
+```csharp
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+
+[FunctionName("CosmosDbSample")]
+public static async Task Run(
+    [CosmosDBTrigger("ToDoList","Items", ConnectionStringSetting = "CosmosDB")] IReadOnlyList<Document> documents,
+    TraceWriter log,
+    [DocumentDB("ToDoList", "Migration", ConnectionStringSetting = "CosmosDB", CreateIfNotExists = true)] IAsyncCollector<Document> documentsToStore)
+{
+    foreach (var doc in documents)
+    {
+        log.Info($"Processing document with Id {doc.Id}");
+        // work with the document, process or create a new one
+        await documentsToStore.AddAsync(doc);
+    }
+}
+```
+
+[!include[](../includes/takeaways-heading.md)]
+
+- The Trigger leverages the **Change Feed** feature in Cosmos DB and will trigger the Function on any insert or update (no deletes supported at the moment).
+- In order to use the Trigger, you need to have a second collection to store the checkpoint **leases** generated during the iteration of the Change Feed. You can customize the **leases** collection name and account on the `CosmosDBTrigger` attribute.
+
+[!include[](../includes/read-more-heading.md)]
+
+- [Serverless database compute using Azure Functions](https://docs.microsoft.com/azure/cosmos-db/serverless-computing-database)
+- [Working with the Change Feed support](https://docs.microsoft.com/azure/cosmos-db/change-feed)
+- [Cosmos DB Trigger in Azure Functions](https://docs.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb#trigger)

--- a/sandbox/functions-recipes/includes/cosmos-db-livemigration.md
+++ b/sandbox/functions-recipes/includes/cosmos-db-livemigration.md
@@ -1,6 +1,6 @@
 ## Trigger a Function based on changes in Cosmos DB
 
-You can trigger a Function based on changes in your Cosmos DB collections. In this sample we are sending the changes to a second collection using the `IAsyncCollection` explained in [this other recipe](./cosmos-db-outputcollector). You could process or work with the documents before sending it to the second collection.
+You can trigger a Function based on changes in your Cosmos DB collections. In this sample we are sending the changes to a second collection using the `IAsyncCollection` explained in [this other recipe](./cosmos-db-outputcollector.md). You could process or work with the documents before sending it to the second collection.
 
 ```csharp
 using System.Collections.Generic;

--- a/sandbox/functions-recipes/includes/cosmos-db-outputcollector.md
+++ b/sandbox/functions-recipes/includes/cosmos-db-outputcollector.md
@@ -1,0 +1,42 @@
+## Save multiple documents to a collection
+
+The `IAsyncCollector` lets you save multiple documents within one execution of your Function.
+
+```csharp
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
+
+public class MyClass
+{
+    public string id { get; set; }
+    public string name { get; set; }
+}
+
+[FunctionName("CosmosDbSample")]
+public static async Task<HttpResponseMessage> Run(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)]MyClass[] classes,
+    TraceWriter log,
+    [DocumentDB("ToDoList", "Items", ConnectionStringSetting = "CosmosDB")] IAsyncCollector<MyClass> documentsToStore)
+{
+    log.Info($"Detected {classes.Length} incoming documents");
+    foreach (MyClass aClass in classes)
+    {
+        await documentsToStore.AddAsync(aClass);
+    }
+
+    return new HttpResponseMessage(HttpStatusCode.Created);
+}
+```
+
+[!include[](../includes/takeaways-heading.md)]
+
+- The `IAsyncCollector` can be used with a class or also with `dynamic` (as in `IAsyncCollection<dynamic>`).
+- When `AddAsync` is called, the document is saved, so if you want to implement any error-handling logic, that is the correct spot for a try/catch.
+
+[!include[](../includes/read-more-heading.md)]
+
+- [Cosmos DB (DocumentDB) Output binding documentation](https://docs.microsoft.com/azure/azure-functions/functions-bindings-cosmosdb#output---attributes)

--- a/sandbox/functions-recipes/includes/cosmos-db-staticclient.md
+++ b/sandbox/functions-recipes/includes/cosmos-db-staticclient.md
@@ -65,5 +65,6 @@ public static async Task<HttpResponseMessage> Run(
 
 [!include[](../includes/read-more-heading.md)]
 
+- [Managing connections in Azure Functions](https://github.com/Azure/azure-functions-host/wiki/Managing-Connections)
 - [Cosmos DB Performance tips for .NET](https://docs.microsoft.com/azure/cosmos-db/performance-tips)
 - [ConnectionPolicy definition](https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.client.connectionpolicy?view=azure-dotnet)

--- a/sandbox/functions-recipes/includes/cosmos-db-staticclient.md
+++ b/sandbox/functions-recipes/includes/cosmos-db-staticclient.md
@@ -1,0 +1,58 @@
+## Customize a DocumentClient and reuse it between executions
+
+You can create your own `DocumentClient` and customize it for your needs, while maintaining a single shared instance for all the Function's executions. The single instance is ensured by the use of the `static` keyword when declaring the `DocumentClient`.
+
+```csharp
+using System;
+using System.Configuration;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents;
+using Microsoft.Azure.Documents.Client;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Host;
+
+
+private static string endpointUrl = ConfigurationManager.AppSettings["CosmosDBAccountEndpoint"];
+private static string authorizationKey = ConfigurationManager.AppSettings["CosmosDBAccountKey"];
+private static DocumentClient client = new DocumentClient(new Uri(endpointUrl), authorizationKey);
+
+
+[FunctionName("CosmosDbSample")]
+public static async Task<HttpResponseMessage> Run(
+    [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequestMessage req,
+    TraceWriter log)
+{
+    string id = req.GetQueryNameValuePairs()
+        .FirstOrDefault(q => string.Compare(q.Key, "id", true) == 0)
+        .Value;
+
+    if (string.IsNullOrEmpty(id))
+    {
+        return req.CreateResponse(HttpStatusCode.BadRequest);
+    }
+
+    Uri documentUri = UriFactory.CreateDocumentUri("datacamp", "test", id);
+    Document doc = await client.ReadDocumentAsync(documentUri);
+
+    if (doc == null)
+    {
+        return req.CreateResponse(HttpStatusCode.NotFound);
+    }
+
+    return req.CreateResponse(HttpStatusCode.OK, doc);
+}
+```
+
+[!include[](../includes/takeaways-heading.md)]
+
+- The `static` keyword acts as a Singleton, maintaining the same instance for all the executions within a Function's instance.
+- You can customize your `DocumentClient` with your own `ConnectionPolicy` requirements.
+
+[!include[](../includes/read-more-heading.md)]
+
+- [Cosmos DB Performance tips for .NET](https://docs.microsoft.com/azure/cosmos-db/performance-tips)
+- [ConnectionPolicy definition](https://docs.microsoft.com/dotnet/api/microsoft.azure.documents.client.connectionpolicy?view=azure-dotnet)


### PR DESCRIPTION
This PR adds 3 more Cosmos DB samples:

* Output binding sample using IAsyncCollector
* Correct usage of a custom shared `DocumentClient`
* Trigger sample (live migration scenario).