### PR TITLE
Take takeaways and read more out of tabs

### DIFF
--- a/sandbox/functions-recipes/environment-variables.md
+++ b/sandbox/functions-recipes/environment-variables.md
@@ -7,7 +7,7 @@ keywords: azure functions, functions, host.json, dynamic compute, serverless arc
 ms.service: functions
 ms.devlang: csharp
 ms.topic: article
-ms.date: 10/12/2017
+ms.date: 04/30/2018
 ms.author: marouill
 ---
 

--- a/sandbox/functions-recipes/includes/environment-variables-accessing-settings.md
+++ b/sandbox/functions-recipes/includes/environment-variables-accessing-settings.md
@@ -28,7 +28,7 @@ let Run([<HttpTrigger(AuthorizationLevel.Anonymous, "GET")>] req: HttpRequestMes
 
 [!include[](../includes/takeaways-heading.md)]
 * Environment variables are configured in the `Application Settings` section
-* Use the static `GetEnvironmentVariable` method of the `Environment` type to get access to the
+* Use the static `GetEnvironmentVariable` method of the `Environment` type access them
 
 [!include[](../includes/read-more-heading.md)]
 * [Environment Variables](https://docs.microsoft.com/azure/azure-functions/functions-dotnet-class-library#environment-variables)

--- a/sandbox/functions-recipes/includes/environment-variables-accessing-settings.md
+++ b/sandbox/functions-recipes/includes/environment-variables-accessing-settings.md
@@ -24,6 +24,8 @@ let Run([<HttpTrigger(AuthorizationLevel.Anonymous, "GET")>] req: HttpRequestMes
     req.CreateResponse(HttpStatusCode.OK, sprintf "My setting is %s" customSetting)
 ```
 
+---
+
 [!include[](../includes/takeaways-heading.md)]
 * Environment variables are configured in the `Application Settings` section
 * Use the static `GetEnvironmentVariable` method of the `Environment` type to get access to the


### PR DESCRIPTION
Fix takeaways and read more which are currently under the F# tab.

Side note: we'll need to figure out how these sections will work when we add more languages. Currently they contain .NET specific things like `GetEnvironmentVariable`.