### PR TITLE
Fix Release Notes page

### DIFF
--- a/sandbox/TOC.yml
+++ b/sandbox/TOC.yml
@@ -11,7 +11,7 @@
         href: demos/notbacon.md
       - name: NotHotdog
         href: demos/nothotdog.md
-      - name: GitHubReleaseNotes
+      - name: GitHub Release Notes Generator
         href: demos/github-release-notes.md
     - name: Game Development
       expanded: true

--- a/sandbox/demos/github-release-notes.md
+++ b/sandbox/demos/github-release-notes.md
@@ -23,7 +23,6 @@ The [The GitHub Release Notes Generator](https://github.com/paladique/ReleaseNot
 
 ![Rendered markdown file of release notes](media/github-release-notes/renderednotes.png)
 
-
 ## Requirements
 * An [Azure](https://azure.microsoft.com/en-us/free?WT.mc_id=sandbox-functions-jasmineg) account
 * A [GitHub](https://github.com/join) account
@@ -38,15 +37,19 @@ The generator is a [function app](https://docs.microsoft.com/en-us/azure/azure-f
 - A [queue trigger](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-storage-queue-triggered-function?WT.mc_id=sandbox-functions-jasmineg) that uses the message sent from the webhook to create a markdown file with the repository's Issues and Pull Requests from the last two weeks, using the [Octokit.NET](https://github.com/octokit/octokit.net) library.
 
 ## Steps
-1. Navigate to the Azure Portal and create a storage account. See the [Create a storage account quickstart](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=portal#create-a-general-purpose-storage-account?WT.mc_id=sandbox-functions-jasmineg) to get started. 
-1. Navigate to the new storage account, navigate to the **Blob Service** section, select **Browse Blobs**, then click the **Add Container** button at the top to create a blob container named `releases`. See section on how to [create a container](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container?WT.mc_id=sandbox-functions-jasmineg) for more information. ![Creating a new storage account container](media/github-release-notes/newcontainer.png)
-1. In the same storage account menu, navigate to the **Queue Service** section, select **Browse Queues**, then click the **Add Queue** button at the top to create a queue named `release-queue`.
-1. In the same storage account menu, navigate to **Access keys** and copy the connection string. ![Storage account access keys](media/github-release-notes/storageaccesskeys.png)
-1. Create a function app. See section on how to [create a function app](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function#create-a-function-app?WT.mc_id=sandbox-functions-jasmineg) to get started.
-1. Navigate to the new function, from the overview, click and open **Application settings**, scroll to and click **+ Add new setting**. Name the setting `StorageConnection` and paste the copied connection string into the value field. Click **Save** ![Adding an application setting](media/github-release-notes/appsettings.png)
-1. In the function app, add a C# GitHub webhook function. See section on how to [Create a GitHub webhook triggered function](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-github-webhook-triggered-function#create-a-github-webhook-triggered-function?WT.mc_id=sandbox-functions-jasmineg) to get started.
 
-1. Replace initial code with the following:
+### Create A Queue and Blob Container
+1. Navigate to the Azure Portal and create a storage account. See the [Create a storage account quickstart](https://docs.microsoft.com/en-us/azure/storage/common/storage-quickstart-create-account?tabs=portal#create-a-general-purpose-storage-account?WT.mc_id=sandbox-functions-jasmineg) to get started. 
+2. Navigate to the new storage account, navigate to the **Blob Service** section, select **Browse Blobs**, then click the **Add Container** button at the top to create a blob container named `releases`. See section on how to [create a container](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-portal#create-a-container?WT.mc_id=sandbox-functions-jasmineg) for more information. ![Creating a new storage account container](media/github-release-notes/newcontainer.png)
+3. In the same storage account menu, navigate to the **Queue Service** section, select **Browse Queues**, then click the **Add Queue** button at the top to create a queue named `release-queue`.
+4. In the same storage account menu, navigate to **Access keys** and copy the connection string. ![Storage account access keys](media/github-release-notes/storageaccesskeys.png)
+
+### Create and Configure a GitHub Webhook Triggered Function
+1. Create a function app. See section on how to [create a function app](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-first-azure-function#create-a-function-app?WT.mc_id=sandbox-functions-jasmineg) to get started.
+2. Navigate to the new function, from the overview, click and open **Application settings**, scroll to and click **+ Add new setting**. Name the setting `StorageConnection` and paste the copied connection string into the value field. Click **Save** ![Adding an application setting](media/github-release-notes/appsettings.png)
+3. In the function app, add a C# GitHub webhook function. See section on how to [Create a GitHub webhook triggered function](https://docs.microsoft.com/en-us/azure/azure-functions/functions-create-github-webhook-triggered-function#create-a-github-webhook-triggered-function?WT.mc_id=sandbox-functions-jasmineg) to get started.
+
+4. Replace initial code with the following:
 
 ```csharp
 using System.Net;
@@ -67,25 +70,28 @@ public static async Task Run(HttpRequestMessage req, ICollector<string> releaseQ
 }
 ```
 
-1. In your new function, copy the url by clicking click **</> Get function URL**, and save for later. Repeat for **</> Get GitHub secret**. You will use these values to configure the webhook in GitHub. ![Location of function url and GitHub secret](media/github-release-notes/functionurl.png)
-1. Expand the function's context menu, navigate to **Integrate** .
-1. Add a new queue storage output. Set the queue name to `release-queue`, Message parameter name to `myQueueItem`, and Storage account connection to `StorageConnection` ![Adding queue storage output](media/github-release-notes/addqueue.png)
+5. In your new function, copy the url by clicking click **</> Get function URL**, and save for later. Repeat for **</> Get GitHub secret**. You will use these values to configure the webhook in GitHub. ![Location of function url and GitHub secret](media/github-release-notes/functionurl.png)
+6. Expand the function's context menu, navigate to **Integrate** .
+7. Add a new queue storage output. Set the queue name to `release-queue`, Message parameter name to `myQueueItem`, and Storage account connection to `StorageConnection` ![Adding queue storage output](media/github-release-notes/addqueue.png)
+
+### Configure GitHub Webhook
 1. Navigate to GitHub and select the repository to use with webhook. Navgiate to the repository's settings.
-1. In the menu on the left of the repository settings, select webhooks and click **add a webhook** button. ![Adding a webhook in GitHub](media/github-release-notes/addgithubwebhook.png)
-1. Follow the table to configure your settings:
+2. In the menu on the left of the repository settings, select webhooks and click **add a webhook** button. ![Adding a webhook in GitHub](media/github-release-notes/addgithubwebhook.png)
+3. Follow the table to configure your settings:
 
 | Setting | Suggested value | Description |
 |---|---|---|
 | **Payload URL** | Copied value | Use the value returned by  **</> Get function URL**. |
 | **Content type** | application/json | The function expects a JSON payload. |
 | **Secret**   | Copied value | Use the value returned by  **</> Get GitHub secret**. |
-| Event triggers | Let me select individual events | We only want to trigger on release events.  |
-| | Releases |  |
+| **Event triggers** | Let me select individual events | We only want to trigger on release events.  |
 
-1. Click **add webhook**.
-1. Navigate to your GitHub user settings, then to **Developer Applications**. Click **New OAuth App** and create an app with a homepage url and callback url of your choice. They will not be used. Copy and save the application name for later use. ![Creating a new Oauth app in GitHub](media/github-release-notes/newghapplication.png)
+4. Click **add webhook**.
+5. Navigate to your GitHub user settings, then to **Developer Applications**. Click **New OAuth App** and create an app with a homepage url and callback url of your choice. They will not be used. Copy and save the application name for later use. ![Creating a new Oauth app in GitHub](media/github-release-notes/newghapplication.png)
+
+### Create a Queue Trigger Function
 1. Navigate back the portal and return to the function app's Application Settings tab. Add a setting named `ReleaseNotesApp`, with the value as the name of the application created in the previous step. Click **Save**.
-1. In the same function app, create a C# queue trigger function. Replace initial code with the following:
+2. In the same function app, create a C# queue trigger function. Replace initial code with the following:
 
 ```csharp
 #r "Microsoft.WindowsAzure.Storage"
@@ -139,7 +145,7 @@ public static async Task<string> GetReleaseDetails(IssueTypeQualifier type, stri
 }
 ```
 
-1. Navigate to queue trigger, add a blob binding to function.json. It should look similar to this:
+3. Navigate to queue trigger, add a blob binding to function.json. It should look similar to this:
 
 ```
   {
@@ -163,7 +169,7 @@ public static async Task<string> GetReleaseDetails(IssueTypeQualifier type, stri
 }
 ```
 
-1. In the same function, upload or create a project.json file and add the following:
+4. In the same function, upload or create a project.json file and add the following:
 
 ```
 {

--- a/sandbox/demos/github-release-notes.md
+++ b/sandbox/demos/github-release-notes.md
@@ -20,8 +20,10 @@ The [The GitHub Release Notes Generator](https://github.com/paladique/ReleaseNot
 [![Deploy to Azure](https://azuredeploy.net/deploybutton.png)](https://azuredeploy.net/?repository=https://github.com/paladique/ReleaseNotesGenerator)
 
 ![Example release on GitHub](media/github-release-notes/exp_release.png)
+_Example release on GitHub_
 
-![Rendered markdown file of release notes](media/github-release-notes/renderednotes.png)
+![Rendered markdown file of example release notes](media/github-release-notes/renderednotes.png)
+_Rendered markdown file of example release notes_
 
 ## Requirements
 * An [Azure](https://azure.microsoft.com/en-us/free?WT.mc_id=sandbox-functions-jasmineg) account

--- a/sandbox/demos/index.yml
+++ b/sandbox/demos/index.yml
@@ -40,7 +40,7 @@ sections:
       href: nothotdog
       image:
         src: https://docs.microsoft.com/azure/media/index/api_vis_computervision.svg
-    - title: GitHubReleaseNotes
+    - title: GitHub Release Notes Generator
       html: <p>Generate release notes when creating a new release with Azure Functions and storage</p>
       href: github-release-notes
       image:

--- a/sandbox/index.yml
+++ b/sandbox/index.yml
@@ -27,7 +27,7 @@ sections:
   - type: list
     style: cards
     className: cardsM
-    columns: 3
+    columns: 2
     items:
     - title: OctoBot
       html: <p>Manage GitHub repos and issues in a chat window using Bot Framework and LUIS.ai</p>
@@ -44,6 +44,11 @@ sections:
       href: demos/nothotdog
       image:
         src: https://docs.microsoft.com/azure/media/index/api_vis_computervision.svg
+    - title: GitHub Release Notes Generator
+      html: <p>Generate release notes when creating a new release with Azure Functions and storage</p>
+      href: github-release-notes
+      image:
+        src: https://docs.microsoft.com/azure/media/index/AzureFunctions.svg
 - title: Game Development
   items:
   - type: paragraph


### PR DESCRIPTION
Adding fixes, per @BrianPeek's suggestions:

- [x] TOC -> Change the name from GitHubReleaseNotes to “GitHub Release Notes Generator” or some such.

- [x]  Add a tile to the Demos and Code section on the front page…maybe change the # of columns back to 2 so it stacks nicely

- [x] There’s something wonky with the table in the article…”Event triggers” isn’t bolded, and there’s an additional row with just the word “Releases”…I don’t know if that’s intentional, but I didn’t understand what it meant?

- [x] Add a caption or title or something to the first image that shows the output?  Because of the background of the image against the white background of Docs, I wasn’t sure what the images were…
