### PR TITLE
tidy up code examples

### DIFF
--- a/sandbox/functions-recipes/includes/service-bus-trigger.md
+++ b/sandbox/functions-recipes/includes/service-bus-trigger.md
@@ -4,7 +4,7 @@ Queues and Topics from Azure Service Bus can be used as triggers for your functi
 Using the `ServiceBusTrigger` attribute, you can supply the queue or topic name, along with the connection information for the Service Bus instance.
 
 ```csharp
- [FunctionName("ServiceBusQueueTrigger)]
+ [FunctionName("ServiceBusQueueTrigger")]
  public static void Run([ServiceBusTrigger("funcqueue", AccessRights.Manage, Connection = "ConnectionSetting")]string queueMessage,
                         TraceWriter log)
  {
@@ -16,7 +16,7 @@ Using the `ServiceBusTrigger` attribute, you can supply the queue or topic name,
 Topic Trigger
 ```csharp
 [FunctionName("ServiceBusTopicTrigger")]
-public static void RunTopic([ServiceBusTrigger("functopic","sampletopic", AccessRights.Manage, Connection = "ConnectionSetting")]string topicMessage,
+public static void RunTopic([ServiceBusTrigger("functopic", "sampletopic", AccessRights.Manage, Connection = "ConnectionSetting")]string topicMessage,
                              TraceWriter log)
 {
     log.Info("101 Azure Function Demo - Service Bus Topic Trigger");


### PR DESCRIPTION
added a quotation mark to get correct syntax highlighting + added space for consistency.