### PR TITLE
Decorated function with NoAutomaticTriggerAttribute

### DIFF
--- a/sandbox/functions-recipes/includes/manual-trigger.md
+++ b/sandbox/functions-recipes/includes/manual-trigger.md
@@ -5,6 +5,7 @@ The following example is a function that must be triggered manually. The Azure p
 ```csharp
 using System;
 
+[NoAutomaticTrigger]
 public static void Run(string input, TraceWriter log)
 {
     log.Info($"This is a manually triggered C# function with input: {input}");


### PR DESCRIPTION
The recent Azure Function runtime won't detect the function because the function has no trigger and is not decorated with NoAutomaticTriggerAttribute. Updated the code snippet to be compliant.