### PR TITLE
Update route prefix example

### DIFF
--- a/sandbox/functions-recipes/includes/routes-prefixes.md
+++ b/sandbox/functions-recipes/includes/routes-prefixes.md
@@ -4,8 +4,10 @@ By default Azure Functions has a route prefix on all functions /api/. To change 
 
 ```json
 {
-  "http": {
-    "routePrefix": ""
+  "extensions": {
+    "http": {
+      "routePrefix": ""
+    }
   }
 }
 ```


### PR DESCRIPTION
The route prefix example's `host.json` file omits the `extensions` property, which means the example doesn't work. [This is documented here.](https://docs.microsoft.com/en-us/azure/azure-functions/functions-host-json)

This PR makes the example work by adding the `extensions` property.