### PR TITLE
fix broken ILogger link

### DIFF
--- a/sandbox/functions-recipes/includes/logging-ilogger.md
+++ b/sandbox/functions-recipes/includes/logging-ilogger.md
@@ -37,4 +37,4 @@ let Run([<HttpTrigger(AuthorizationLevel.Anonymous, "GET")>] req: HttpRequestMes
 
 [!include[](../includes/read-more-heading.md)]
 * [ILogger support](https://github.com/Azure/azure-webjobs-sdk-script/wiki/ILogger)
-* [ILogger extension methods](https://docs.microsoft.com/aspnet/core/api/microsoft.extensions.logging.loggerextensions#methods_summary)
+* [ILogger extension methods](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loggerextensions)

--- a/sandbox/functions-recipes/includes/logging-ilogger.md
+++ b/sandbox/functions-recipes/includes/logging-ilogger.md
@@ -1,5 +1,5 @@
 ## Logging with ILogger
-As an alternative to `TraceWriter`, an instance of [`ILogger`](https://docs.microsoft.com/aspnet/core/api/microsoft.extensions.logging.ilogger) can be used instead.
+As an alternative to `TraceWriter`, an instance of [`ILogger`](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.ilogger) can be used instead.
 
 The advantage of using `ILogger` instead of `TraceWriter` is that you get support for structured logging, which allows for richer analytics support. This is helpful if you target your logs at a tool like [Application Insights](https://docs.microsoft.com/azure/application-insights/app-insights-analytics).
 


### PR DESCRIPTION
the link to the ILogger interface is broken (or has moved) change updates to a correct link.